### PR TITLE
feat: added next episode caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akuse-beta",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akuse-beta",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -300,20 +300,22 @@ const clientId = '1212475013408628818';
 const RPC = new DiscordRPC.Client({ transport: 'ipc' });
 DiscordRPC.register(clientId);
 
-// const startTimestamp = new Date();
+//const startTimestamp = new Date();
 
-async function setActivity() {
+async function setActivity(details?: string, state?: string, startTimestamp?: number, largeImageKey?: string, largeImageText?: string, smallImageKey?: string, instance?: boolean, buttons?: any[]) {
   if (!RPC || !mainWindow) {
     return;
   }
 
   RPC.setActivity({
-    details: 'Watch anime without ads.',
-    startTimestamp: Date.now(),
-    largeImageKey: 'icon',
-    largeImageText: 'Akuse',
-    instance: false,
-    buttons: [
+    details: details || 'Watch anime without ads.',
+    state: state || 'Browsing the homepage.',
+    startTimestamp: startTimestamp || Date.now(),
+    largeImageKey: largeImageKey || 'icon',
+    largeImageText: largeImageText || 'Akuse',
+    smallImageKey: 'icon',
+    instance: instance || false,
+    buttons: buttons || [
       {
         label: 'Download app',
         url: 'https://github.com/akuse-app/akuse/releases/latest',
@@ -324,10 +326,10 @@ async function setActivity() {
 
 RPC.on('ready', () => {
   setActivity();
-
-  setInterval(() => {
-    setActivity();
-  }, 15 * 1000);
 });
-
 RPC.login({ clientId }).catch(console.error);
+
+ipcMain.on('update-presence', (event, data) => {
+  console.log("update presence fired")
+  setActivity(data.details, data.state, data.startTimestamp, data.largeImageKey, data.largeImageText, data.instance, data.buttons);
+})

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -19,6 +19,7 @@ import { EpisodeInfo } from '../../../types/types';
 import BottomControls from './BottomControls';
 import MidControls from './MidControls';
 import TopControls from './TopControls';
+import { ipcRenderer } from 'electron';
 
 const STORE = new Store();
 const style = getComputedStyle(document.body);
@@ -63,6 +64,19 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [episodeTitle, setEpisodeTitle] = useState<string>('');
   const [episodeDescription, setEpisodeDescription] = useState<string>('');
   const [progressUpdated, setProgressUpdated] = useState<boolean>(false);
+  const [activity, setActivity] = useState<boolean>(false);
+
+  if(!activity && episodeTitle){
+    setActivity(true);
+    ipcRenderer.send("update-presence", {
+      details: `Watching ${listAnimeData.media.title?.english}`,
+      state: `${episodeTitle} [${episodeNumber}/${listAnimeData.media.episodes}]`,
+      startTimestamp: Date.now(),
+      largeImageKey: listAnimeData.media.coverImage?.large || "icon",
+      largeImageText: listAnimeData.media.title?.english || "Akuse",
+      smallImageKey: 'icon',
+      buttons: [{label: "Download app", url: "https://github.com/akuse-app/akuse/releases/latest"}]})
+  }
 
   // controls
   const [showControls, setShowControls] = useState<boolean>(false);
@@ -389,6 +403,20 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       document.exitFullscreen();
     }
     onClose();
+    ipcRenderer.send("update-presence", {
+      details: `Watch anime without ads.`,
+      state: `Browsing the homepage`,
+      startTimestamp: Date.now(),
+      largeImageKey: "icon",
+      largeImageText: "Akuse",
+      instance: true,
+      buttons: [
+        {
+          label: 'Download app',
+          url: 'https://github.com/akuse-app/akuse/releases/latest',
+        },
+      ],
+    })
   };
 
   const toggleFullScreenWithoutPropagation = (event: any) => {


### PR DESCRIPTION
When the current episode is loading/loaded, it will have the next episode's data cached which will allow for instant skipping, instead of the current 3-5 second wait.

I don't know React too much so someone could probably optimise this further.