### PR TITLE
Related Anime, Bug fixes, and Omelette's request

### DIFF
--- a/src/modules/anilist/anilistApi.ts
+++ b/src/modules/anilist/anilistApi.ts
@@ -2,15 +2,13 @@ import { app, ipcRenderer } from 'electron';
 import Store from 'electron-store';
 
 import {
-  AiringPage,
-  AiringScheduleData,
   AnimeData,
   CurrentListAnime,
   ListAnimeData,
   MostPopularAnime,
   TrendingAnime,
 } from '../../types/anilistAPITypes';
-import { MediaListStatus } from '../../types/anilistGraphQLTypes';
+import { AiringPage, AiringSchedule, MediaListStatus } from '../../types/anilistGraphQLTypes';
 import { ClientData } from '../../types/types';
 import { clientData } from '../clientData';
 import isAppImage from '../packaging/isAppImage';
@@ -28,6 +26,7 @@ const HEADERS: Object = {
 const MEDIA_DATA: string = `
         id
         idMal
+        type
         title {
             romaji
             english
@@ -81,6 +80,71 @@ const MEDIA_DATA: string = `
             id
             site
             thumbnail
+        }
+        relations {
+          edges {
+            id
+            relationType(version: 2)
+            node {
+              id
+              idMal
+              type
+              title {
+                  romaji
+                  english
+                  native
+                  userPreferred
+              }
+              format
+              status
+              description
+              startDate {
+                  year
+                  month
+                  day
+              }
+              endDate {
+                  year
+                  month
+                  day
+              }
+              season
+              seasonYear
+              episodes
+              duration
+              coverImage {
+                  large
+                  extraLarge
+                  color
+              }
+              bannerImage
+              genres
+              synonyms
+              averageScore
+              meanScore
+              popularity
+              favourites
+              isAdult
+              nextAiringEpisode {
+                  id
+                  timeUntilAiring
+                  episode
+              }
+              mediaListEntry {
+                  id
+                  mediaId
+                  status
+                  score(format:POINT_10)
+                  progress
+              }
+              siteUrl
+              trailer {
+                  id
+                  site
+                  thumbnail
+              }
+            }
+          }
         }
     `;
 
@@ -441,7 +505,7 @@ export const getAiringSchedule = async (
   const options = getOptions(query);
   const respData = await makeRequest(METHOD, GRAPH_QL_URL, headers, options);
 
-  return respData.data.Page.airingSchedules as AiringScheduleData[];
+  return respData.data.Page.airingSchedules as AiringSchedule[];
 };
 
 /**

--- a/src/modules/anilist/anilistApi.ts
+++ b/src/modules/anilist/anilistApi.ts
@@ -1,4 +1,4 @@
-import { app, ipcRenderer } from 'electron';
+import { app } from 'electron';
 import Store from 'electron-store';
 
 import {
@@ -8,11 +8,12 @@ import {
   MostPopularAnime,
   TrendingAnime,
 } from '../../types/anilistAPITypes';
-import { AiringPage, AiringSchedule, MediaListStatus } from '../../types/anilistGraphQLTypes';
+import { AiringPage, AiringSchedule, Media, MediaListStatus} from '../../types/anilistGraphQLTypes';
 import { ClientData } from '../../types/types';
 import { clientData } from '../clientData';
 import isAppImage from '../packaging/isAppImage';
 import { getOptions, makeRequest } from '../requests';
+
 
 const STORE: any = new Store();
 const CLIENT_DATA: ClientData = clientData;
@@ -377,7 +378,7 @@ export const getAnimesFromTitles = async (titles: string[]) => {
  * @param {*} animeId
  * @returns object with anime info
  */
-export const getAnimeInfo = async (animeId: any) => {
+export const getAnimeInfo = async (animeId: any): Promise<Media> => {
   var query = `
           query($id: Int) {
               Media(id: $id, type: ANIME) {
@@ -399,7 +400,7 @@ export const getAnimeInfo = async (animeId: any) => {
   const options = getOptions(query, variables);
   const respData = await makeRequest(METHOD, GRAPH_QL_URL, headers, options);
 
-  return respData.data.Media;
+  return respData.data.Media as Media;
 };
 
 /**

--- a/src/modules/history.ts
+++ b/src/modules/history.ts
@@ -29,6 +29,19 @@ export const getHistoryEntries = (): HistoryEntries => history.entries;
 export const getHistory = (): History => history;
 
 /**
+ * Get history entry for a specific episode
+ *
+ * @param animeId
+ * @param episodeNumber
+ * @returns history entry
+ */
+export const getEpisodeHistory = (
+  animeId: number,
+  episodeNumber: number
+): EpisodeHistoryEntry | undefined => getAnimeHistory(animeId)?.history[episodeNumber]
+
+
+/**
  * Set local history.
  *
  * @param newHistory

--- a/src/modules/requests.ts
+++ b/src/modules/requests.ts
@@ -4,9 +4,7 @@ var remainingRequests = 90;
 var resetTime = 0;
 var lockUntil = 0;
 
-async function delay(seconds: number) {
-  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
-}
+const delay = async (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 
 const handleRateLimiting = async (current: number) => {
   if (current < lockUntil) {

--- a/src/modules/requests.ts
+++ b/src/modules/requests.ts
@@ -1,5 +1,37 @@
 import axios from 'axios';
 
+var remainingRequests = 90;
+var resetTime = 0;
+var lockUntil = 0;
+
+async function delay(seconds: number) {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+
+const handleRateLimiting = async (current: number) => {
+  if (current < lockUntil) {
+    await delay(lockUntil - current);
+  }
+
+  if (current >= resetTime) {
+    remainingRequests = 90;
+  }
+
+  if (remainingRequests <= 0) {
+    await delay(60);
+  }
+};
+
+const handleResponseHeaders = (headers: any) => {
+  if (headers['x-ratelimit-remaining']) {
+    remainingRequests = parseInt(headers['x-ratelimit-remaining']);
+  }
+
+  if (headers['x-ratelimit-reset']) {
+    resetTime = parseInt(headers['x-ratelimit-reset']);
+  }
+};
+
 /**
  * Builds the data options for the request
  *
@@ -24,12 +56,43 @@ export const getOptions = (query: any = {}, variables: any = {}) => {
  * @returns object with the fetched data
  * @throws error if the request was not successful
  */
+
 export const makeRequest = async (
   method: 'GET' | 'POST' | string,
   url: string,
   headers: any = {},
   options: any = {},
-) => {
+): Promise<any> => {
+  if (url === 'https://graphql.anilist.co') {
+    const current = Date.now() / 1000;
+
+    await handleRateLimiting(current);
+
+    try {
+      const response = await axios({
+        method: method,
+        url: url,
+        headers: headers,
+        data: options,
+      });
+
+      handleResponseHeaders(response.headers);
+
+      return response.data;
+    } catch (error) {
+      let response = (error as { response?: { status: number, headers: { [key: string]: any } } }).response;
+
+      if (response && response.status === 429) {
+        const retryAfter = parseInt(response.headers['retry-after'] || '60', 10);
+        lockUntil = current + retryAfter;
+        await delay(retryAfter);
+        return makeRequest(method, url, headers, options);
+      }
+
+      throw error;
+    }
+  }
+
   const response = await axios({
     method: method,
     url: url,

--- a/src/modules/storeVariables.ts
+++ b/src/modules/storeVariables.ts
@@ -7,6 +7,7 @@ const defaultValues = {
   dubbed: false,
   source_flag: 'US',
   intro_skip_time: 85,
+  key_press_skip: 5,
   show_duration: true,
   trailer_volume_on: false,
   volume: 1,

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,5 +1,5 @@
-import { AiringScheduleData, AnimeData, ListAnimeData } from '../types/anilistAPITypes';
-import { Media, MediaFormat, MediaStatus } from '../types/anilistGraphQLTypes';
+import { AnimeData, ListAnimeData } from '../types/anilistAPITypes';
+import { AiringSchedule, Media, MediaFormat, MediaStatus, Relation, Relations } from '../types/anilistGraphQLTypes';
 import { getLastWatchedEpisode } from './history';
 
 const MONTHS = {
@@ -46,17 +46,30 @@ export const getRandomDiscordPhrase = (): string =>
   DISCORD_PHRASES[Math.floor(Math.random() * DISCORD_PHRASES.length)];
 
 export const airingDataToListAnimeData = (
-  airingScheduleData: AiringScheduleData[]
+  airingScheduleData: AiringSchedule[]
 ): ListAnimeData[] => {
   return airingScheduleData.map((value) => {
     return {
       id: null,
       mediaId: null,
       progress: null,
-      media: value.media
+      media: value.media as Media
     };
   });
 };
+
+export const relationsToListAnimeData = (
+  relations: Relation[]
+): ListAnimeData[] => {
+  return relations.map((value) => {
+    return {
+      id: null,
+      mediaId: null,
+      progress: null,
+      media: value.node
+    }
+  })
+}
 
 export const animeDataToListAnimeData = (
   animeData: AnimeData,

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -180,7 +180,7 @@ export const getProgress = (animeEntry: Media): number | undefined => {
   const lastWatched = getLastWatchedEpisode(animeId);
 
   if(lastWatched !== undefined && lastWatched.data !== undefined) {
-    const progress = (lastWatched.data.episodeNumber as number) - 1;
+    const progress = (lastWatched.data.episodeNumber as number) - ((lastWatched.duration as number * 0.85) > lastWatched.time ? 1 : 0);
     return Number.isNaN(progress) ? 0 : progress;
   }
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -229,10 +229,14 @@ export const getProgress = (animeEntry: Media): number | undefined => {
   const animeId = (animeEntry.id || animeEntry?.mediaListEntry?.id) as number;
   const lastWatched = getLastWatchedEpisode(animeId);
 
-  const anilistProgress = animeEntry.mediaListEntry == null ? 0 : animeEntry.mediaListEntry.progress;
+  const anilistProgress = animeEntry.mediaListEntry === null ? 0 : animeEntry?.mediaListEntry?.progress;
 
-  if(anilistProgress === 0 && lastWatched !== undefined && lastWatched.data !== undefined) {
-    const localProgress = (parseInt(lastWatched.data.episode ?? "0")) - ((lastWatched.duration as number * 0.85) > lastWatched.time ? 1 : 0);
+  if(lastWatched !== undefined && lastWatched.data !== undefined) {
+    const isFinished = (lastWatched.duration as number * 0.85) > lastWatched.time;
+    const localProgress = (parseInt(lastWatched.data.episode ?? "0")) - (isFinished ? 1 : 0);
+    if(anilistProgress !== 0 && anilistProgress)
+      return anilistProgress - (isFinished ? 1 : 0);
+
     return Number.isNaN(localProgress) ? 0 : localProgress;
   }
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -308,6 +308,7 @@ export const getParsedFormat = (format: MediaFormat | undefined) => {
     case 'MOVIE':
       return 'Movie';
     case 'SPECIAL':
+    case 'SUMMARY':
       return 'Special';
     case 'OVA':
       return 'OVA';
@@ -315,6 +316,12 @@ export const getParsedFormat = (format: MediaFormat | undefined) => {
       return 'ONA';
     case 'MUSIC':
       return 'Music';
+    case 'SEQUEL':
+      return 'Sequel';
+    case 'PREQUEL':
+      return 'Prequel';
+    case 'ALTERNATIVE':
+      return 'Alternative';
     default:
       return '?';
   }

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -229,12 +229,14 @@ export const getProgress = (animeEntry: Media): number | undefined => {
   const animeId = (animeEntry.id || animeEntry?.mediaListEntry?.id) as number;
   const lastWatched = getLastWatchedEpisode(animeId);
 
-  if(lastWatched !== undefined && lastWatched.data !== undefined) {
-    const progress = (parseInt(lastWatched.data.episode ?? "0")) - ((lastWatched.duration as number * 0.85) > lastWatched.time ? 1 : 0);
-    return Number.isNaN(progress) ? 0 : progress;
+  const anilistProgress = animeEntry.mediaListEntry == null ? 0 : animeEntry.mediaListEntry.progress;
+
+  if(anilistProgress === 0 && lastWatched !== undefined && lastWatched.data !== undefined) {
+    const localProgress = (parseInt(lastWatched.data.episode ?? "0")) - ((lastWatched.duration as number * 0.85) > lastWatched.time ? 1 : 0);
+    return Number.isNaN(localProgress) ? 0 : localProgress;
   }
 
-  return animeEntry.mediaListEntry == null ? 0 : animeEntry.mediaListEntry.progress;
+  return anilistProgress;
 }
 
 /**

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -117,6 +117,8 @@ export default function App() {
       result = Object.values(result).sort(sortNewest);
     }
 
+    console.log(result);
+
     setCurrentListAnime(result);
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,19 +9,15 @@ import { SkeletonTheme } from 'react-loading-skeleton';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import {
-  getAiringSchedule,
   getMostPopularAnime,
   getNextReleases,
   getTrendingAnime,
   getViewerId,
   getViewerInfo,
   getViewerList,
-  getAnimesFromTitles,
-  getAiredAnime
 } from '../modules/anilist/anilistApi';
 
-import { getRecentEpisodes } from '../modules/providers/gogoanime';
-import { airingDataToListAnimeData, animeDataToListAnimeData } from '../modules/utils';
+import { animeDataToListAnimeData } from '../modules/utils';
 import { ListAnimeData, UserInfo } from '../types/anilistAPITypes';
 import MainNavbar from './MainNavbar';
 import Tab1 from './tabs/Tab1';
@@ -30,14 +26,13 @@ import Tab3 from './tabs/Tab3';
 import Tab4 from './tabs/Tab4';
 
 import { setDefaultStoreVariables } from '../modules/storeVariables';
-import { IpcRenderer, ipcRenderer, IpcRendererEvent } from 'electron';
+import { ipcRenderer, IpcRendererEvent } from 'electron';
 import AutoUpdateModal from './components/modals/AutoUpdateModal';
 import WindowControls from './WindowControls';
 import { OS } from '../modules/os';
 import DonateModal from './components/modals/DonateModal';
 import { getHistoryEntries, getLastWatchedEpisode } from '../modules/history';
 import Tab5 from './tabs/Tab5';
-import { AnimeHistoryEntry } from '../types/historyTypes';
 
 ipcRenderer.on('console-log', (event, toPrint) => {
   console.log(toPrint);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -117,8 +117,6 @@ export default function App() {
       result = Object.values(result).sort(sortNewest);
     }
 
-    console.log(result);
-
     setCurrentListAnime(result);
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -92,8 +92,9 @@ export default function App() {
 
       const current = await getViewerList(id, 'CURRENT');
       const rewatching = await getViewerList(id, 'REPEATING');
+      const paused = await getViewerList(id, 'PAUSED');
 
-      result = result.concat(current.concat(rewatching));
+      result = result.concat(current.concat(rewatching).concat(paused));
     } else if(historyAvailable) {
       setHasHistory(true);
       result = Object.values(entries).map((value) => value.data).sort(sortNewest);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -48,6 +48,7 @@ export default function App() {
   const [showUpdateModal, setShowUpdateModal] = useState<boolean>(false);
   const [showDonateModal, setShowDonateModal] = useState<boolean>(false);
   const [hasHistory, setHasHistory] = useState<boolean>(false);
+  const [sectionUpdate, setSectionUpdate] = useState<number>(0);
 
   // tab1
   const [userInfo, setUserInfo] = useState<UserInfo>();
@@ -117,6 +118,9 @@ export default function App() {
 
   useEffect(() => {
       const updateSectionListener = async (event: IpcRendererEvent, ...sections: string[]) => {
+        const current = Date.now() / 1000;
+        if(current - sectionUpdate < 2) return;
+        setSectionUpdate(current);
         for(const section of sections) {
           switch(section) {
             case 'history':
@@ -131,7 +135,7 @@ export default function App() {
       return () => {
           ipcRenderer.removeListener('update-section', updateSectionListener);
       };
-  });
+  }, [sectionUpdate]);
 
   ipcRenderer.on('auto-update', async () => {
     setShowDonateModal(false);

--- a/src/renderer/components/AnimeEntry.tsx
+++ b/src/renderer/components/AnimeEntry.tsx
@@ -97,7 +97,7 @@ const AnimeEntry: React.FC<{
           <Skeleton className="anime-cover" />
         )}
 
-        <div className="content">
+        <div className="anime-content">
           <div className="anime-title">
             {listAnimeData ? (
               <>

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -125,9 +125,7 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
   const fetchEpisodesInfo = async () => {
     const animeId = listAnimeData.media.id as number;
 
-    const lastWatched = getLastWatchedEpisode(animeId);
-    if(lastWatched && lastWatched.data)
-      setLocalProgress((lastWatched.data.episodeNumber as number) - 1);
+    setLocalProgress(getProgress(listAnimeData.media));
 
     axios
       .get(`${EPISODES_INFO_URL}${animeId}`)

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -92,12 +92,11 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
   const getRelatedAnime = async () => {
     if(listAnimeData.media?.relations === undefined) {
       /* If you click on a related anime this'll run. */
-      const media: Media = await getAnimeInfo(listAnimeData.media.id)
       listAnimeData = {
         id: null,
         mediaId: null,
         progress: null,
-        media: media
+        media: await getAnimeInfo(listAnimeData.media.id),
       }
     }
     const edges = listAnimeData.media.relations?.edges;

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -376,10 +376,6 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
             />
             {relatedAnime && relatedAnime.length > 0 &&
               <div
-                style={{
-                  marginLeft: '25px',
-                  display: 'flex'
-                }}
                 className='related-anime'
               >
                 <AnimeSection

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -90,7 +90,6 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
   const [relatedAnime, setRelatedAnime] = useState<ListAnimeData[]>();
 
   const getRelatedAnime = async () => {
-
     if(listAnimeData.media?.relations === undefined) {
       /* If you click on a related anime this'll run. */
       listAnimeData = {
@@ -100,9 +99,6 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
         media: await getAnimeInfo(listAnimeData.media.id)
       }
     }
-
-    console.log(listAnimeData, listAnimeData.media)
-
     const edges = listAnimeData.media.relations?.edges;
     if(!edges) return;
 

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -126,7 +126,7 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
     const animeId = listAnimeData.media.id as number;
 
     const lastWatched = getLastWatchedEpisode(animeId);
-    if(lastWatched)
+    if(lastWatched && lastWatched.data)
       setLocalProgress((lastWatched.data.episodeNumber as number) - 1);
 
     axios

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -98,6 +98,8 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
         progress: null,
         media: await getAnimeInfo(listAnimeData.media.id),
       }
+
+      setLocalProgress(getProgress(listAnimeData.media));
     }
     const edges = listAnimeData.media.relations?.edges;
     if(!edges) return;
@@ -375,9 +377,7 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
               onPlay={playEpisode}
             />
             {relatedAnime && relatedAnime.length > 0 &&
-              <div
-                className='related-anime'
-              >
+              <div className='related-anime'>
                 <AnimeSection
                   title='Related'
                   animeData={relatedAnime}

--- a/src/renderer/components/modals/AnimeModal.tsx
+++ b/src/renderer/components/modals/AnimeModal.tsx
@@ -44,7 +44,7 @@ import EpisodesSection from './EpisodesSection';
 import { ModalPage, ModalPageShadow } from './Modal';
 import { ipcRenderer } from 'electron';
 import { getLastWatchedEpisode } from '../../../modules/history';
-import { MediaTypes } from '../../../types/anilistGraphQLTypes';
+import { Media, MediaFormat, MediaTypes } from '../../../types/anilistGraphQLTypes';
 import AnimeSection from '../AnimeSection';
 import { Dots } from 'react-activity';
 import AnimeEntry from '../AnimeEntry';
@@ -92,17 +92,23 @@ const AnimeModal: React.FC<AnimeModalProps> = ({
   const getRelatedAnime = async () => {
     if(listAnimeData.media?.relations === undefined) {
       /* If you click on a related anime this'll run. */
+      const media: Media = await getAnimeInfo(listAnimeData.media.id)
       listAnimeData = {
         id: null,
         mediaId: null,
         progress: null,
-        media: await getAnimeInfo(listAnimeData.media.id)
+        media: media
       }
     }
     const edges = listAnimeData.media.relations?.edges;
     if(!edges) return;
 
-    const list = edges.filter((value) => value.node.type === MediaTypes.Anime);
+    const list = edges.filter((value) => value.node.type === MediaTypes.Anime).map((value) => {
+      value.node.format = value.node.format === 'TV' ? value.relationType as MediaFormat : value.node.format;
+
+      return value;
+    });
+
     setRelatedAnime(relationsToListAnimeData(list));
   };
 

--- a/src/renderer/components/modals/styles/AnimeModal.css
+++ b/src/renderer/components/modals/styles/AnimeModal.css
@@ -100,7 +100,7 @@
 
 .anime-page .content-wrapper .content {
   display: flex;
-  /* gap: 50px; */
+  gap: 10px;
   width: calc(100% - 50px);
   margin: 0 25px 25px 25px;
   border-radius: var(--border-radius);

--- a/src/renderer/components/modals/styles/AnimeModal.css
+++ b/src/renderer/components/modals/styles/AnimeModal.css
@@ -100,7 +100,7 @@
 
 .anime-page .content-wrapper .content {
   display: flex;
-  gap: 50px;
+  /* gap: 50px; */
   width: calc(100% - 50px);
   margin: 0 25px 25px 25px;
   border-radius: var(--border-radius);

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -302,6 +302,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       data: listAnimeData,
     };
 
+    console.log(episodeNumber, (episodesInfo as EpisodeInfo[])[episodeNumber]);
+
     entry.history[episodeNumber] = {
       time: cTime,
       timestamp: Date.now(),

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -302,7 +302,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       data: listAnimeData,
     };
 
-    console.log(episodeNumber, (episodesInfo as EpisodeInfo[])[episodeNumber]);
+    if(episodeNumber === 0) return;
 
     entry.history[episodeNumber] = {
       time: cTime,

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -411,7 +411,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         setCurrentTime(cTime);
         setDuration(dTime);
         setBuffered(videoRef.current?.buffered);
-        handleHistoryUpdate();
+        // handleHistoryUpdate();
 
         if (
           (cTime * 100) / dTime > 85 &&

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -228,7 +228,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   }, [loading]);
 
   const getSkipEvents = async (episode: number) => {
-    const skipEvent = await AniSkip.getSkipEvents(listAnimeData.media.idMal as number, episode ?? episodeNumber ?? animeEpisodeNumber);
+    const duration = videoRef.current?.duration;
+    const skipEvent = await AniSkip.getSkipEvents(listAnimeData.media.idMal as number, episode ?? episodeNumber ?? animeEpisodeNumber, Number.isNaN(duration) ? 0 : duration);
 
     setSkipEvents(skipEvent);
   }

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -266,7 +266,6 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       setShowNextEpisodeButton(canNextEpisode(animeEpisodeNumber));
       setShowPreviousEpisodeButton(canPreviousEpisode(animeEpisodeNumber));
       getSkipEvents(animeEpisodeNumber);
-
     }
   }, [video, listAnimeData]);
 
@@ -367,36 +366,38 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   const updateCurrentProgress = (completed: boolean = true) => {
     const status = listAnimeData.media.mediaListEntry?.status;
-    if(!completed) {
-      updateAnimeFromList(
-        listAnimeData.media.id,
-        'PAUSED',
-        undefined,
-        episodeNumber,
-      );
-      handleHistoryUpdate();
-    }else if (STORE.get('logged') as boolean) {
-      switch (status) {
-        case 'CURRENT': {
-          updateAnimeProgress(listAnimeData.media.id!, episodeNumber);
-          break;
-        }
-        case 'REPEATING':
-        case 'COMPLETED': {
-          updateAnimeFromList(
-            listAnimeData.media.id,
-            'REWATCHING',
-            undefined,
-            episodeNumber,
-          );
-        }
-        default: {
-          updateAnimeFromList(
-            listAnimeData.media.id,
-            'CURRENT',
-            undefined,
-            episodeNumber,
-          );
+    if (STORE.get('logged') as boolean) {
+      if(!completed) {
+        updateAnimeFromList(
+          listAnimeData.media.id,
+          'PAUSED',
+          undefined,
+          episodeNumber,
+        );
+        handleHistoryUpdate();
+      } else {
+        switch (status) {
+          case 'CURRENT': {
+            updateAnimeProgress(listAnimeData.media.id!, episodeNumber);
+            break;
+          }
+          case 'REPEATING':
+          case 'COMPLETED': {
+            updateAnimeFromList(
+              listAnimeData.media.id,
+              'REWATCHING',
+              undefined,
+              episodeNumber,
+            );
+          }
+          default: {
+            updateAnimeFromList(
+              listAnimeData.media.id,
+              'CURRENT',
+              undefined,
+              episodeNumber,
+            );
+          }
         }
       }
     }

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -127,7 +127,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       }
       case 'ArrowLeft': {
         event.preventDefault();
-        video.currentTime -= 5;
+        video.currentTime -= STORE.get('key_press_skip') as number;
         break;
       }
       case 'ArrowUp': {
@@ -137,7 +137,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       }
       case 'ArrowRight': {
         event.preventDefault();
-        video.currentTime += 5;
+        video.currentTime += STORE.get('key_press_skip') as number;
         break;
       }
       case 'ArrowDown': {

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -10,13 +10,16 @@ import ReactDOM from 'react-dom';
 import toast, { Toaster } from 'react-hot-toast';
 
 import {
+  getAnimeInfo,
   updateAnimeFromList,
   updateAnimeProgress,
 } from '../../../modules/anilist/anilistApi';
 import { getUniversalEpisodeUrl } from '../../../modules/providers/api';
 import {
   getAvailableEpisodes,
+  getMediaListId,
   getRandomDiscordPhrase,
+  getSequel,
 } from '../../../modules/utils';
 import { ListAnimeData } from '../../../types/anilistAPITypes';
 import { EpisodeInfo } from '../../../types/types';
@@ -26,6 +29,9 @@ import TopControls from './TopControls';
 import { getAnimeHistory, setAnimeHistory } from '../../../modules/history';
 import AniSkip from '../../../modules/aniskip';
 import { SkipEvent } from '../../../types/aniskipTypes';
+import { getEnvironmentData } from 'node:worker_threads';
+import axios from 'axios';
+import { EPISODES_INFO_URL } from '../../../constants/utils';
 
 const STORE = new Store();
 const style = getComputedStyle(document.body);
@@ -72,15 +78,17 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [episodeDescription, setEpisodeDescription] = useState<string>('');
   const [progressUpdated, setProgressUpdated] = useState<boolean>(false);
   const [activity, setActivity] = useState<boolean>(false);
+  const [listAnime, setListAnime] = useState<ListAnimeData>(listAnimeData);
+  const [episodeList, setEpisodeList] = useState<EpisodeInfo[] | undefined>(episodesInfo);
 
   if (!activity && episodeTitle) {
     setActivity(true);
     ipcRenderer.send('update-presence', {
-      details: `Watching ${listAnimeData.media.title?.english}`,
+      details: `Watching ${listAnime.media.title?.english}`,
       state: episodeTitle,
       startTimestamp: Date.now(),
-      largeImageKey: listAnimeData.media.coverImage?.large || 'akuse',
-      largeImageText: listAnimeData.media.title?.english || 'akuse',
+      largeImageKey: listAnime.media.coverImage?.large || 'akuse',
+      largeImageText: listAnime.media.title?.english || 'akuse',
       smallImageKey: 'icon',
       buttons: [
         {
@@ -229,7 +237,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   const getSkipEvents = async (episode: number) => {
     const duration = videoRef.current?.duration;
-    const skipEvent = await AniSkip.getSkipEvents(listAnimeData.media.idMal as number, episode ?? episodeNumber ?? animeEpisodeNumber, Number.isNaN(duration) ? 0 : duration);
+    const skipEvent = await AniSkip.getSkipEvents(listAnime.media.idMal as number, episode ?? episodeNumber ?? animeEpisodeNumber, Number.isNaN(duration) ? 0 : duration);
 
     setSkipEvents(skipEvent);
   }
@@ -239,9 +247,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       playHlsVideo(video.url);
 
       // resume from tracked progress
-      const animeId = (listAnimeData.media.id ||
-        (listAnimeData.media.mediaListEntry &&
-          listAnimeData.media.mediaListEntry.id)) as number;
+      const animeId = (listAnime.media.id ||
+        (listAnime.media.mediaListEntry &&
+          listAnime.media.mediaListEntry.id)) as number;
       const animeHistory = getAnimeHistory(animeId);
 
       if (animeHistory !== undefined) {
@@ -254,20 +262,20 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       setVideoData(video);
       setEpisodeNumber(animeEpisodeNumber);
       setEpisodeTitle(
-        episodesInfo
-          ? (episodesInfo[animeEpisodeNumber].title?.en ??
+        episodeList
+          ? (episodeList[animeEpisodeNumber].title?.en ??
               `Episode ${animeEpisodeNumber}`)
           : `Episode ${animeEpisodeNumber}`,
       );
       setEpisodeDescription(
-        episodesInfo ? (episodesInfo[animeEpisodeNumber].summary ?? '') : '',
+        episodeList ? (episodeList[animeEpisodeNumber].summary ?? '') : '',
       );
 
       setShowNextEpisodeButton(canNextEpisode(animeEpisodeNumber));
       setShowPreviousEpisodeButton(canPreviousEpisode(animeEpisodeNumber));
       getSkipEvents(animeEpisodeNumber);
     }
-  }, [video, listAnimeData]);
+  }, [video, listAnime]);
 
   const playHlsVideo = (url: string) => {
     try {
@@ -293,20 +301,20 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     const video = videoRef.current;
     const cTime = video?.currentTime;
     if (cTime === undefined) return;
-    const animeId = (listAnimeData.media.id ||
-      (listAnimeData.media.mediaListEntry &&
-        listAnimeData.media.mediaListEntry.id)) as number;
+    const animeId = (listAnime.media.id ||
+      (listAnime.media.mediaListEntry &&
+        listAnime.media.mediaListEntry.id)) as number;
     if (animeId === null || animeId === undefined || episodeNumber === 0) return;
     let entry = getAnimeHistory(animeId) ?? {
       history: {},
-      data: listAnimeData,
+      data: listAnime,
     };
 
     entry.history[episodeNumber] = {
       time: cTime,
       timestamp: Date.now(),
       duration: video?.duration,
-      data: (episodesInfo as EpisodeInfo[])[episodeNumber],
+      data: (episodeList as EpisodeInfo[])[episodeNumber],
     };
 
     setAnimeHistory(entry);
@@ -365,11 +373,11 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   };
 
   const updateCurrentProgress = (completed: boolean = true) => {
-    const status = listAnimeData.media.mediaListEntry?.status;
+    const status = listAnime.media.mediaListEntry?.status;
     if (STORE.get('logged') as boolean) {
       if(!completed) {
         updateAnimeFromList(
-          listAnimeData.media.id,
+          listAnime.media.id,
           'PAUSED',
           undefined,
           episodeNumber,
@@ -378,13 +386,13 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       } else {
         switch (status) {
           case 'CURRENT': {
-            updateAnimeProgress(listAnimeData.media.id!, episodeNumber);
+            updateAnimeProgress(listAnime.media.id!, episodeNumber);
             break;
           }
           case 'REPEATING':
           case 'COMPLETED': {
             updateAnimeFromList(
-              listAnimeData.media.id,
+              listAnime.media.id,
               'REWATCHING',
               undefined,
               episodeNumber,
@@ -392,7 +400,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
           }
           default: {
             updateAnimeFromList(
-              listAnimeData.media.id,
+              listAnime.media.id,
               'CURRENT',
               undefined,
               episodeNumber,
@@ -560,13 +568,48 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     }
   };
 
+  const getEpisodeCount = () => {
+    const episodes = episodeList && Object.values(episodeList).filter((value) =>
+      !Number.isNaN(parseInt(value.episode ?? '0')));
+
+    return episodes?.length ?? 0;
+  }
+
   const changeEpisode = async (
     episode: number | null, // null to play the current episode
     reloadAtPreviousTime?: boolean,
   ): Promise<boolean> => {
     onChangeLoading(true);
 
-    const episodeToPlay = episode || episodeNumber;
+    const sequel = getSequel(listAnime.media);
+    const episodeCount = getEpisodeCount();
+
+    let episodeToPlay = episode || episodeNumber;
+    let episodes = episodeList;
+    let anime = listAnime;
+
+    if(episodeCount < episodeToPlay && sequel) {
+      const animeId = sequel.id;
+      const media = await getAnimeInfo(sequel.id);
+
+      anime = {
+        id: null,
+        mediaId: null,
+        progress: null,
+        media: media,
+      }
+      setListAnime(anime);
+
+      episodeToPlay = 1;
+      animeEpisodeNumber = 1;
+
+      const data = await axios.get(`${EPISODES_INFO_URL}${animeId}`);
+
+      if (data.data && data.data.episodes) {
+        episodes = data.data.episodes
+        setEpisodeList(episodes);
+      }
+    }
 
     var previousTime = 0;
     if (reloadAtPreviousTime && videoRef.current)
@@ -577,12 +620,12 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       setEpisodeNumber(episodeToPlay);
       getSkipEvents(episodeToPlay);
       setEpisodeTitle(
-        episodesInfo
-          ? (episodesInfo[episodeToPlay].title?.en ?? `Episode ${episode}`)
-          : `Episode ${episode}`,
+        episodes
+          ? (episodes[episodeToPlay].title?.en ?? `Episode ${episodeToPlay}`)
+          : `Episode ${episodeToPlay}`,
       );
       setEpisodeDescription(
-        episodesInfo ? (episodesInfo[episodeToPlay].summary ?? '') : '',
+        episodes ? (episodes[episodeToPlay].summary ?? '') : '',
       );
       playHlsVideo(value.url);
       // loadSource(value.url, value.isM3U8 ?? false);
@@ -600,7 +643,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       onChangeLoading(false);
     };
 
-    const data = await getUniversalEpisodeUrl(listAnimeData, episodeToPlay);
+    const data = await getUniversalEpisodeUrl(anime, episodeToPlay);
     if (!data) {
       toast(`Source not found.`, {
         style: {
@@ -623,7 +666,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   };
 
   const canNextEpisode = (episode: number): boolean => {
-    return episode !== getAvailableEpisodes(listAnimeData.media);
+    const hasNext = episode !== getAvailableEpisodes(listAnime.media);
+
+    if(!hasNext) {
+      const sequel = getSequel(listAnime.media);
+
+      if (!sequel) return false;
+      return getAvailableEpisodes(sequel) !== null;
+    }
+
+    return hasNext;
   };
 
   return ReactDOM.createPortal(
@@ -639,7 +691,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
             <div className="content">
               <h1 className="you-are-watching">You are watching</h1>
               <h1 id="pause-info-anime-title">
-                {listAnimeData.media.title?.english}
+                {listAnime.media.title?.english}
               </h1>
               <h1 id="pause-info-episode-title">{episodeTitle}</h1>
               <h1 id="pause-info-episode-description">{episodeDescription}</h1>
@@ -653,8 +705,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
             <TopControls
               videoRef={videoRef}
               hls={hlsData}
-              listAnimeData={listAnimeData}
-              episodesInfo={episodesInfo}
+              listAnimeData={listAnime}
+              episodesInfo={episodeList}
               episodeNumber={episodeNumber}
               episodeTitle={episodeTitle}
               showNextEpisodeButton={showNextEpisodeButton}

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -296,13 +296,11 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     const animeId = (listAnimeData.media.id ||
       (listAnimeData.media.mediaListEntry &&
         listAnimeData.media.mediaListEntry.id)) as number;
-    if (animeId === null || animeId === undefined) return;
+    if (animeId === null || animeId === undefined || episodeNumber === 0) return;
     let entry = getAnimeHistory(animeId) ?? {
       history: {},
       data: listAnimeData,
     };
-
-    if(episodeNumber === 0) return;
 
     entry.history[episodeNumber] = {
       time: cTime,

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -26,7 +26,6 @@ import TopControls from './TopControls';
 import { getAnimeHistory, setAnimeHistory } from '../../../modules/history';
 import AniSkip from '../../../modules/aniskip';
 import { SkipEvent } from '../../../types/aniskipTypes';
-import { skip } from 'node:test';
 
 const STORE = new Store();
 const style = getComputedStyle(document.body);

--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -265,7 +265,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
       setShowNextEpisodeButton(canNextEpisode(animeEpisodeNumber));
       setShowPreviousEpisodeButton(canPreviousEpisode(animeEpisodeNumber));
-      getSkipEvents(animeEpisodeNumber)
+      getSkipEvents(animeEpisodeNumber);
+
     }
   }, [video, listAnimeData]);
 
@@ -366,7 +367,15 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   const updateCurrentProgress = (completed: boolean = true) => {
     const status = listAnimeData.media.mediaListEntry?.status;
-    if (STORE.get('logged') as boolean) {
+    if(!completed) {
+      updateAnimeFromList(
+        listAnimeData.media.id,
+        'PAUSED',
+        undefined,
+        episodeNumber,
+      );
+      handleHistoryUpdate();
+    }else if (STORE.get('logged') as boolean) {
       switch (status) {
         case 'CURRENT': {
           updateAnimeProgress(listAnimeData.media.id!, episodeNumber);
@@ -493,7 +502,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     }
 
     onClose();
-    if (STORE.get('update_progress') as boolean) updateCurrentProgress(false);
+    if (STORE.get('update_progress'))
+      updateCurrentProgress((currentTime ?? 0) > (duration ?? 0) * 0.85);
 
     ipcRenderer.send('update-presence', {
       details: `🌸 Watch anime without ads.`,

--- a/src/renderer/components/player/VideoSettings.tsx
+++ b/src/renderer/components/player/VideoSettings.tsx
@@ -116,9 +116,9 @@ const VideoSettings: React.FC<SettingsProps> = ({
     setHlsData(hls);
   }, [hls]);
 
-  const handleQualityChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleQualityChange = (index: number) => {
     if (hlsData) {
-      hlsData.currentLevel = parseInt(event.target.value);
+      hlsData.currentLevel = index;
     }
   };
 

--- a/src/renderer/components/player/VideoSettings.tsx
+++ b/src/renderer/components/player/VideoSettings.tsx
@@ -222,7 +222,7 @@ const VideoSettings: React.FC<SettingsProps> = ({
             </span>
             {hlsData && (
               <Select
-                zIndex={12}
+                zIndex={13}
                 options={[
                   ...hlsData?.levels?.map((level, index) => ({
                     label: `${level.height}p`,

--- a/src/renderer/components/player/VideoSettings.tsx
+++ b/src/renderer/components/player/VideoSettings.tsx
@@ -58,8 +58,12 @@ const VideoSettings: React.FC<SettingsProps> = ({
   const [selectedLanguage, setSelectedLanguage] = useState<string>(
     STORE.get('source_flag') as string,
   );
-  const [skipTime, setSkipTime] = useState<number>(
+  const [introSkipTime, setIntroSkipTime] = useState<number>(
     STORE.get('intro_skip_time') as number,
+  );
+
+  const [skipTime, setSkipTime] = useState<number>(
+    STORE.get('key_press_skip') as number,
   );
 
   const [isMuted, setIsMuted] = useState(false);
@@ -188,8 +192,13 @@ const VideoSettings: React.FC<SettingsProps> = ({
     }
   };
 
-  const handleSkipTimeChange = (value: any) => {
+  const handleIntroSkipTimeChange = (value: any) => {
     STORE.set('intro_skip_time', parseInt(value));
+    setIntroSkipTime(parseInt(value));
+  };
+
+  const handleSkipTimeChange = (value: any) => {
+    STORE.set('key_press_skip', parseInt(value));
     setSkipTime(parseInt(value));
   };
 
@@ -252,7 +261,7 @@ const VideoSettings: React.FC<SettingsProps> = ({
               Speed
             </span>
             <Select
-              zIndex={11}
+              zIndex={12}
               options={[
                 { label: '0.25', value: '0.25' },
                 { label: '0.50', value: '0.50' },
@@ -265,6 +274,25 @@ const VideoSettings: React.FC<SettingsProps> = ({
               ]}
               selectedValue={speed}
               onChange={handleSpeedChange}
+              width={100}
+            />
+          </li>
+          <li className="skip-time">
+            <span>
+              <FontAwesomeIcon className="i label" icon={faRotateRight} />
+              Skip Time
+            </span>
+            <Select
+              zIndex={11}
+              options={[
+                { label: '1', value: 1 },
+                { label: '2', value: 2 },
+                { label: '3', value: 3 },
+                { label: '4', value: 4 },
+                { label: '5', value: 5 },
+              ]}
+              selectedValue={skipTime}
+              onChange={handleSkipTimeChange}
               width={100}
             />
           </li>
@@ -285,8 +313,8 @@ const VideoSettings: React.FC<SettingsProps> = ({
                 { label: '90', value: 90 },
                 { label: '95', value: 95 },
               ]}
-              selectedValue={skipTime}
-              onChange={handleSkipTimeChange}
+              selectedValue={introSkipTime}
+              onChange={handleIntroSkipTimeChange}
               width={100}
             />
           </li>

--- a/src/renderer/components/styles/AnimeEntry.css
+++ b/src/renderer/components/styles/AnimeEntry.css
@@ -80,7 +80,7 @@
   font-size: 1rem;
   color: var(--font-1);
   font-weight: 800;
-  min-height: 42px;
+  /* min-height: 42px; */
 
   display: -webkit-box;
   -webkit-line-clamp: 2;

--- a/src/renderer/components/styles/AnimeEntry.css
+++ b/src/renderer/components/styles/AnimeEntry.css
@@ -1,4 +1,4 @@
-main .anime-entry {
+.anime-entry {
   position: relative;
   width: 175px;
   height: min-content;
@@ -9,19 +9,19 @@ main .anime-entry {
   will-change: transform;
 }
 
-main .anime-entry:not(.skeleton) {
+.anime-entry:not(.skeleton) {
   cursor: pointer;
 }
 
-main .anime-entry:not(.skeleton):hover {
+.anime-entry:not(.skeleton):hover {
   transform: scale(1.06);
 }
 
-main .anime-entry:not(.skeleton):hover .anime-cover {
+.anime-entry:not(.skeleton):hover .anime-cover {
   outline: 3px solid var(--font-1);
 }
 
-main .anime-entry .content {
+.anime-entry .content {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -33,7 +33,7 @@ main .anime-entry .content {
   z-index: 3;
 }
 
-main .anime-entry .anime-cover {
+.anime-entry .anime-cover {
   height: 262.5px;
   position: relative;
   object-fit: cover;
@@ -44,14 +44,14 @@ main .anime-entry .anime-cover {
   /* box-shadow: var(--shadow-cover); */
 }
 
-main .anime-entry .anime-cover img {
+.anime-entry .anime-cover img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   border-radius: var(--border-radius);
 }
 
-main .anime-entry.disabled {
+.anime-entry.disabled {
   border: 3px dashed var(--color-3);
   color: var(--color-3);
   font-weight: var(--font-weight);
@@ -59,13 +59,13 @@ main .anime-entry.disabled {
   cursor: auto;
 }
 
-main .anime-entry .anime-cover.disabled {
+.anime-entry .anime-cover.disabled {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-main .anime-entry .anime-cover .anime-cover-shadow {
+.anime-entry .anime-cover .anime-cover-shadow {
   position: absolute;
   top: 0;
   left: 0;
@@ -75,7 +75,7 @@ main .anime-entry .anime-cover .anime-cover-shadow {
   border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 
-main .anime-entry .anime-title {
+.anime-entry .anime-title {
   /* font-size: 0.9rem; */
   font-size: 1rem;
   color: var(--font-1);
@@ -89,24 +89,24 @@ main .anime-entry .anime-title {
   overflow: hidden;
 }
 
-main .anime-entry .anime-title span {
+.anime-entry .anime-title span {
   margin-right: 0px;
   font-size: 1rem;
 }
 
-main .anime-entry .anime-title span.up-to-date {
+.anime-entry .anime-title span.up-to-date {
   color: var(--color-info);
 }
 
-main .anime-entry .anime-title span.releasing {
+.anime-entry .anime-title span.releasing {
   color: var(--color-success);
 }
 
-main .anime-entry .anime-title span.not-yet-released {
+.anime-entry .anime-title span.not-yet-released {
   color: var(--color-alert);
 }
 
-main .anime-entry .anime-info {
+.anime-entry .anime-info {
   display: flex;
   gap: 5px;
   /* font-size: 0.9rem; */
@@ -115,11 +115,11 @@ main .anime-entry .anime-info {
   font-weight: var(--font-weight);
 }
 
-main .anime-entry .anime-info .i {
+.anime-entry .anime-info .i {
   font-size: 1.1rem;
 }
 
-main .anime-entry .anime-info .season-year {
+.anime-entry .anime-info .season-year {
   display: flex;
   justify-content: start;
   align-items: center;
@@ -127,7 +127,7 @@ main .anime-entry .anime-info .season-year {
   width: 75%;
 }
 
-main .anime-entry .anime-info .episodes {
+.anime-entry .anime-info .episodes {
   display: flex;
   justify-content: end;
   align-items: center;
@@ -135,7 +135,7 @@ main .anime-entry .anime-info .episodes {
   text-align: end;
 }
 
-main .anime-entry .anime-progress {
+.anime-entry .anime-progress {
   color: var(--font-3);
   font-size: 1rem;
   font-weight: var(--font-weight);

--- a/src/renderer/components/styles/AnimeEntry.css
+++ b/src/renderer/components/styles/AnimeEntry.css
@@ -21,7 +21,7 @@
   outline: 3px solid var(--font-1);
 }
 
-.anime-entry .content {
+.anime-entry .anime-content {
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/renderer/components/styles/AnimeSection.css
+++ b/src/renderer/components/styles/AnimeSection.css
@@ -1,4 +1,4 @@
-main section .anime-list-wrapper {
+section .anime-list-wrapper {
   padding: 50px;
   margin: -50px;
   position: relative;
@@ -10,7 +10,7 @@ main section .anime-list-wrapper {
   /* disable if drag n scroll is enabled */
 }
 
-main section .anime-list {
+section .anime-list {
   float: left;
   width: max-content;
   gap: 25px;

--- a/src/renderer/components/styles/AnimeSection.css
+++ b/src/renderer/components/styles/AnimeSection.css
@@ -26,4 +26,5 @@ section#related-section {
   overflow-y: hidden;
   /* height: 25%; */
   width: calc(100% - 30px);
+  padding-left: 25px;
 }

--- a/src/renderer/components/styles/AnimeSection.css
+++ b/src/renderer/components/styles/AnimeSection.css
@@ -19,3 +19,11 @@ section .anime-list {
   padding-bottom: 10px;
   z-index: 2;
 }
+
+section#related-section {
+  display: flex;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  /* height: 25%; */
+  width: calc(100% - 30px);
+}

--- a/src/renderer/tabs/Tab4.tsx
+++ b/src/renderer/tabs/Tab4.tsx
@@ -121,7 +121,7 @@ const Tab4: React.FC = () => {
   const [selectedLanguage, setSelectedLanguage] = useState<string>(
     STORE.get('source_flag') as string,
   );
-  const [skipTime, setSkipTime] = useState<number>(
+  const [introSkipTime, setIntroSkipTime] = useState<number>(
     STORE.get('intro_skip_time') as number,
   );
   const [showDuration, setShowDuration] = useState<boolean>(
@@ -130,17 +130,16 @@ const Tab4: React.FC = () => {
   const [episodesPerPage, setEpisodesPerPage] = useState<number>(
     STORE.get('episodes_per_page') as number,
   );
+  const [skipTime, setSkipTime] = useState<number>(
+    STORE.get('key_press_skip') as number
+  );
 
   const [clearHistory, setClearHistory] = useState<boolean>(false);
 
+
   const handleEpisodesPerPage = (value: any) => {
-    if (/[a-zA-Z\.]/.test(value)) value = value.replaceAll(/[a-zA-Z\.]/g, '');
-
-    let number = Math.max(Number(value), 1);
-    if (Number.isNaN(number)) number = 1;
-
-    STORE.set('episodes_per_page', number);
-    setEpisodesPerPage(number);
+    STORE.set('episodes_per_page', parseInt(value));
+    setEpisodesPerPage(parseInt(value));
   };
 
   const handleClearHistory = () => {
@@ -163,9 +162,14 @@ const Tab4: React.FC = () => {
     setSelectedLanguage(value);
   };
 
+  const handleIntroSkipTimeChange = (value: any) => {
+    STORE.set('intro_skip_time', parseInt(value));
+    setIntroSkipTime(parseInt(value));
+  };
+
   const handleSkipTimeChange = (value: any) => {
     STORE.set('intro_skip_time', parseInt(value));
-    setSkipTime(parseInt(value));
+    setIntroSkipTime(parseInt(value));
   };
 
   const handleShowDurationChange = () => {
@@ -193,7 +197,7 @@ const Tab4: React.FC = () => {
     { value: 50, label: '50' },
   ];
 
-  const skipTimeOptions: Option[] = [
+  const introSkipTimeOptions: Option[] = [
     { value: 60, label: '60' },
     { value: 65, label: '65' },
     { value: 70, label: '70' },
@@ -202,6 +206,14 @@ const Tab4: React.FC = () => {
     { value: 85, label: '85' },
     { value: 90, label: '90' },
     { value: 95, label: '95' },
+  ];
+
+  const skipTimeOptions: Option[] = [
+    { label: '1', value: 1 },
+    { label: '2', value: 2 },
+    { label: '3', value: 3 },
+    { label: '4', value: 4 },
+    { label: '5', value: 5 },
   ];
 
   return (
@@ -220,6 +232,14 @@ const Tab4: React.FC = () => {
 
           <SelectElement
             label="Select the duration of the default intro skip (in seconds)"
+            value={introSkipTime}
+            options={introSkipTimeOptions}
+            zIndex={3}
+            onChange={handleIntroSkipTimeChange}
+          />
+
+          <SelectElement
+            label="Select the amount you want to skip using the arrows"
             value={skipTime}
             options={skipTimeOptions}
             zIndex={3}

--- a/src/renderer/tabs/Tab4.tsx
+++ b/src/renderer/tabs/Tab4.tsx
@@ -234,7 +234,7 @@ const Tab4: React.FC = () => {
             label="Select the duration of the default intro skip (in seconds)"
             value={introSkipTime}
             options={introSkipTimeOptions}
-            zIndex={2}
+            zIndex={3}
             onChange={handleIntroSkipTimeChange}
           />
 
@@ -242,7 +242,7 @@ const Tab4: React.FC = () => {
             label="Select the amount you want to skip using the arrows"
             value={skipTime}
             options={skipTimeOptions}
-            zIndex={3}
+            zIndex={2}
             onChange={handleSkipTimeChange}
           />
 

--- a/src/renderer/tabs/Tab4.tsx
+++ b/src/renderer/tabs/Tab4.tsx
@@ -169,7 +169,7 @@ const Tab4: React.FC = () => {
 
   const handleSkipTimeChange = (value: any) => {
     STORE.set('intro_skip_time', parseInt(value));
-    setIntroSkipTime(parseInt(value));
+    setSkipTime(parseInt(value));
   };
 
   const handleShowDurationChange = () => {

--- a/src/renderer/tabs/Tab4.tsx
+++ b/src/renderer/tabs/Tab4.tsx
@@ -234,7 +234,7 @@ const Tab4: React.FC = () => {
             label="Select the duration of the default intro skip (in seconds)"
             value={introSkipTime}
             options={introSkipTimeOptions}
-            zIndex={3}
+            zIndex={4}
             onChange={handleIntroSkipTimeChange}
           />
 
@@ -242,7 +242,7 @@ const Tab4: React.FC = () => {
             label="Select the amount you want to skip using the arrows"
             value={skipTime}
             options={skipTimeOptions}
-            zIndex={2}
+            zIndex={3}
             onChange={handleSkipTimeChange}
           />
 

--- a/src/renderer/tabs/Tab4.tsx
+++ b/src/renderer/tabs/Tab4.tsx
@@ -234,7 +234,7 @@ const Tab4: React.FC = () => {
             label="Select the duration of the default intro skip (in seconds)"
             value={introSkipTime}
             options={introSkipTimeOptions}
-            zIndex={3}
+            zIndex={2}
             onChange={handleIntroSkipTimeChange}
           />
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -284,18 +284,18 @@ main {
   color: #fff;
 } */
 
-main section {
+section {
   display: flex;
   flex-direction: column;
   position: relative;
   z-index: 2;
 }
 
-main section.hide-section {
+section.hide-section {
   display: none;
 }
 
-main section:not(:last-child) {
+section:not(:last-child) {
   margin-bottom: 15px;
 }
 
@@ -306,7 +306,7 @@ h1 {
   margin-bottom: 15px;
 }
 
-main section .scrollers {
+section .scrollers {
   position: absolute;
   top: 0;
   right: 0;

--- a/src/types/anilistAPITypes.tsx
+++ b/src/types/anilistAPITypes.tsx
@@ -21,20 +21,6 @@ export type ListAnimeData = {
   media: Media
 }
 
-export type AiringPage = {
-  airingSchedules: AiringScheduleData[]
-  pageInfo: {
-    hasNextPage: boolean
-  }
-}
-
-export type AiringScheduleData = {
-  episode: number
-  airingAt: number,
-  media: Media,
-  timeUntilAiring: number
-}
-
 export type TrendingAnime = AnimeData
 export type MostPopularAnime = AnimeData
 export type CurrentListAnime = ListAnimeData[]

--- a/src/types/anilistGraphQLTypes.tsx
+++ b/src/types/anilistGraphQLTypes.tsx
@@ -16,6 +16,13 @@ export type MediaFormat =
   | 'MANGA'
   | 'NOVEL'
   | 'ONE_SHOT'
+  // Lazy related stuff
+  | 'SEQUEL'
+  | 'PREQUEL'
+  | 'ALTERNATIVE'
+  | 'SIDE_STORY'
+  | 'CHARACTER'
+  | 'SUMMARY'
 
 export type MediaStatus =
   | 'FINISHED'

--- a/src/types/anilistGraphQLTypes.tsx
+++ b/src/types/anilistGraphQLTypes.tsx
@@ -39,6 +39,11 @@ export type MediaCoverImage = {
   color?: string;
 };
 
+export type AiringPage = {
+  airingSchedules: AiringSchedule[]
+  pageInfo: PageInfo
+}
+
 export type AiringSchedule = {
   id: number;
   airingAt: number;
@@ -76,8 +81,37 @@ export type PageInfo = {
   hasNextPage: boolean;
 };
 
+export const RelationTypes = {
+  Source: 'SOURCE',
+  Alternative: 'ALTERNATIVE',
+  Other: 'OTHER',
+  Prequel: 'PREQUEL',
+  Sequel: 'SEQUEL',
+  Character: 'CHARACTER'
+};
+
+export type RelationType = typeof RelationTypes[keyof typeof RelationTypes];
+
+export type Relation = {
+  id: number;
+  relationType: RelationType;
+  node: Media;
+};
+
+export type Relations = {
+  edges: Relation[];
+};
+
+export const MediaTypes = {
+  Anime: 'ANIME',
+  Manga: 'MANGA'
+};
+
+export type MediaType = typeof MediaTypes[keyof typeof MediaTypes];
+
 export type Media = {
   id?: number;
+  type?: MediaType;
   idMal?: number;
   title?: MediaTitle;
   format?: MediaFormat;
@@ -102,4 +136,5 @@ export type Media = {
   mediaListEntry?: MediaList;
   siteUrl?: string;
   trailer?: MediaTrailer;
+  relations?: Relations;
 };

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -7,6 +7,7 @@ export type EpisodeInfo = {
   airdate?: string
   length?: string | number
   episodeNumber?: number
+  episode?: string
 };
 
 export type ClientData = {


### PR DESCRIPTION
## Changes
- [x] If you're finished an episode it'll set the progress to the next one
- [x] Prioritize Anilist progress over local progress.
- [x] Changeable arrow seek time.
- [x] Related anime section at the bottom of the anime modal.
- [x] Stops rate limiting from causing an error instead it waits until it can make another request. 
- [x] Press "Next Episode" on the last episode of an anime to go to the sequel.
- [x] If you exit an anime without finishing it'll set it as paused on anilist.
<sub>Uncheck anything you want me to remove.</sub>

## Issues
- #137
- #131
- #142
- #146
- #147

## Latest Build
https://github.com/ch0nker/akuse/releases/tag/1.6.5

## Screenshots
![Screenshot_20240902_135624](https://github.com/user-attachments/assets/d8604cd7-c189-46f3-b7ad-78c1fccc909f)
![Screenshot_20240902_135718](https://github.com/user-attachments/assets/c0f23177-4781-47c8-a9c6-2c5a3b20ead9)
![Screenshot_20240903_224721](https://github.com/user-attachments/assets/6cf109ee-305f-4290-b617-be8f47d77636)
