### PR TITLE
feat: added remember quality selection

### DIFF
--- a/src/renderer/components/player/VideoPlayer.tsx
+++ b/src/renderer/components/player/VideoPlayer.tsx
@@ -396,7 +396,9 @@ const VideoPlayer: React.FC<{
         hls.attachMedia(videoRef.current);
         hls.on(Hls.Events.MANIFEST_PARSED, () => {
           if (videoRef.current) {
-            hls.currentLevel = hls.levels.length - 1;
+            const savedQuality = STORE.get('last_quality');
+            hls.currentLevel = savedQuality !== undefined ? savedQuality as number : hls.levels.length - 1;
+          
             playVideoAndSetTime();
             setHlsData(hls);
           }

--- a/src/renderer/components/player/VideoSettings.tsx
+++ b/src/renderer/components/player/VideoSettings.tsx
@@ -116,6 +116,7 @@ const VideoSettings = forwardRef<HTMLDivElement, SettingsProps>(
     const handleQualityChange = (index: number) => {
       if (hlsData) {
         hlsData.currentLevel = index;
+        STORE.set("last_quality", index);
       }
     };
 


### PR DESCRIPTION
The last quality chosen is now persistent
# Todo
- [x] Add settings option for choosing between using last or best quality
- [ ]  Use another value if the saved quality is not available 

- Solves #134 